### PR TITLE
Removing /healthz from node.json as it now matches baseline

### DIFF
--- a/src/TestFiles/node.json
+++ b/src/TestFiles/node.json
@@ -1,5 +1,4 @@
 [
-    {"Url":"/healthz","Validation":{"ContentType":"application/json","JsonObject":[{"Field":"status","Value":"up"}]}},
     {"Url":"/swagger.json","Validation":{"Code":200,"ContentType":"application/json","JsonObject":[{"Field":"openapi","Value":null},{"Field":"info","Value":null},{"Field":"paths","Value":null},{"Field":"components","Value":null}]}},
     {"Url": "/robots.txt", "Validation": {"ContentType": "text/plain","MinLength": 48,"MaxLength": 48,"Contains": [{"Value": "User-agent: *"},{"Value": "Disallow: /"}]}},
     {"Url": "/robots1234.txt","Validation": {"ContentType": "text/plain","MinLength": 48,"MaxLength": 48,"Contains": [{"Value": "User-agent: *"},{"Value": "Disallow: /"}]}},  


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- With the changes in https://github.com/retaildevcrews/helium-typescript/pull/39, there is no longer a "node-specific" healthz endpoint.  This PR removes the /healthz check from node.json as that endpoint is covered in baseline.json. 

## Issues Closed or Referenced

- References #19 and #31
