### PR TITLE
Adding checkpoint template per guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/checkpoint.md
+++ b/.github/ISSUE_TEMPLATE/checkpoint.md
@@ -1,0 +1,37 @@
+---
+name: CP Review
+about: Checkpoint Review checklist
+title: ''
+labels: CP Review, Pri1, Sharing
+assignees: ''
+
+---
+
+This checklist is for verifying the necessary details for a checkpoint review. 
+
+## Checkpoint Review
+
+- [ Milestone, Sprint, Date ]
+- Review Date: [Add Date/Month scheduled]
+
+### "DoneLog" Review
+
+- [ ] What was planned to be done this month?
+- [ ] What was actually done this month?
+- [ ] Changes in plan versus last
+- [ ] Key design decisions and their outcomes
+
+### Demo
+
+- [ ] 5m target
+- [ ] Encouraged to just replay "best of" Sprint Demo
+
+### Key Project Risks and Concerns
+
+- [ ] Present Retro outcomes from the month
+- [ ] Discuss open risks and mitigations
+
+### Backlog Review
+
+- [ ] What is envisioned to be worked on in the sprints this month?
+- [ ] Multi-checkpoint roadmap update (if applicable)


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [X] GitHub Template changes

## Purpose of PR
Add checkpoint checklist per guidelines for review

## Review notes
Template will add tags but doesn't automate Project board

## Issues Closed or Referenced
- Closes #186 

