### PR TITLE
Remove unneeded role assignment

### DIFF
--- a/docs/AppService.md
+++ b/docs/AppService.md
@@ -37,11 +37,8 @@ az webapp log config --docker-container-logging filesystem -g $He_App_RG -n $He_
 ./saveenv.sh -y
 
 ### App Service cannot currently use Managed Identity to access ACR
-### We pull the Service Principal ID and Key from Key Vault via
+### We pull the previously created Service Principal ID and Key from Key Vault via
 ### the @Microsoft.KeyVault() format used in -u and -p below
-
-# assign acrpull access to Service Principal
-az role assignment create --assignee $(eval $He_SP_ID) --scope $He_ACR_Id --role acrpull
 
 # configure the Web App to use Container Registry
 az webapp config container set -n $He_Name -g $He_App_RG \


### PR DESCRIPTION
The role assignment for the SP is created in the main instructions:

```
# assign acrpull access to the Service Principal
az role assignment create --scope $He_ACR_Id --role acrpull --assignee $(eval $He_SP_ID)
```

No need to create it again here:

```
# assign acrpull access to Service Principal
az role assignment create --assignee $(eval $He_SP_ID) --scope $He_ACR_Id --role acrpull
```

## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

### Validation
- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above
 
### Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)

 
