### PR TITLE
Removing query to calculate percentile

### DIFF
--- a/docs/AppService.md
+++ b/docs/AppService.md
@@ -181,16 +181,6 @@ ContainerInstanceLog_CL
 | summarize avg(quartile) by category, tag
 | sort by category
 
-# Average quartile of tests per category and location
-ContainerInstanceLog_CL
-| extend jsonMessage = parsejson(Message)
-| extend category = tostring(jsonMessage.category),
-  duration = toint(jsonMessage.duration),
-  tag = tostring(jsonMessage.tag)
-| where isnotempty(category)
-| summarize percentile(duration, 98) by category, tag
-| sort by category
-
 # Tests with duration exceeding the 98th percentile within the matching category
 ContainerInstanceLog_CL
 | extend jsonMessage = parsejson(Message)


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR
Removing the Log Analytics query to calculate P98 for tests. This is already included as a nested query in the next example, when determining the 'outlier' tests that exceed the 98% threshold.

### Validation
- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above
 
### Issues Closed or Referenced

N/A

 
