### PR TITLE
issue #523 Update documentation for keyvault and soft delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,17 @@ az keyvault secret list-deleted --vault-name $He_Name -o table
 
 ```
 
-If you see the Helium vaults or secrets in this state, you can purge or recover the values before moving forward.
+If you see the Helium vaults or secrets in this state, you can purge or recover the values before moving forward. There are example commands below for deleting and purging a keyvault.
+
+```shell
+
+# Deleting a keyvault if you intend to reuse the same name.
+az keyvault delete -g $He_App_RG -n $He_Name
+
+# Purging a key vault. This will permanently delete the keyvault and all its contents.
+az keyvault purge  -n $He_Name
+
+```
 
 #### Create and load sample data into Cosmos DB
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,23 @@ source ~/.helium.env
 ```bash
 
 ## create the Key Vault
-## do not disable soft-delete in production!
-az keyvault create --enable-soft-delete false -g $He_App_RG -n $He_Name
+az keyvault create -g $He_App_RG -n $He_Name
 
 ```
+
+Key Vault does a soft delete when deleting vaults. If you have gone through this setup already, you could run into errors like "Exist soft deleted vault with the same name.", and "Secret is currently in a deleted but recoverable state ...". You can check if you have deleted vaults and keys with the commands below.
+
+```shell
+
+# list deleted keyvaults that still exist
+az keyvault list-deleted -o table
+
+# list deleted secrets that still exist
+az keyvault secret list-deleted --vault-name $He_Name -o table
+
+```
+
+If you see the Helium vaults or secrets in this state, you can purge or recover the values before moving forward.
 
 #### Create and load sample data into Cosmos DB
 


### PR DESCRIPTION


## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

The ability to disable soft delete for key vault will be deprecated. I updated the documentation to remove that option in the readme. Also added some commands to check if there are any delete vaults and secrets.
https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-change

### Validation
- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above
 
### Issues Closed or Referenced

- Closes #523 

 
