### PR TITLE
issue #522 Add a note about the environment variables that intentionally save commands as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ nslookup ${He_Name}.azurecr.io
   - One for App Service or AKS, Key Vault and Azure Monitor
   - One for Cosmos DB
 
+Some of the environment variables that will be created will be commands for retriving sensitive values. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is to save the actual command as a string.
+
 ```bash
 
 # set location

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ nslookup ${He_Name}.azurecr.io
   - One for App Service or AKS, Key Vault and Azure Monitor
   - One for Cosmos DB
 
-Some environment variables will save commands as strings instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is.
+> Some environment variables will save commands as strings instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is. When the value is needed, the command will be executed with `eval`. For example, `dotnet run -- $Imdb_Name $(eval $Imdb_RW_Key) ...`.
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ nslookup ${He_Name}.azurecr.io
   - One for App Service or AKS, Key Vault and Azure Monitor
   - One for Cosmos DB
 
-Some of the environment variables that will be created will be commands for retriving sensitive values. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is to save the actual command as a string.
+Some environment variables will save commands as strings instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is.
 
 ```bash
 


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

Some of the environment variables intentionally save commands as strings for use at later points in the setup process. Update the documentation to be explicit about that, so that the user does not try to run the commands too early.

imdb edit: https://github.com/retaildevcrews/imdb/pull/55

### Validation
- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above
 
### Issues Closed or Referenced

- References #522

 
