### PR TITLE
Http error response design guide

### DIFF
--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -10,11 +10,11 @@ The HTTP/400 error responses outlined in this document currently only cover API 
 
 The HTTP response contains a "Problem Details Object" which has the following members:
 
-- "type" (string): An optional URI which identifies the problem type.
-- "title" (string): Summary of the problem.
-- "status" (number): Currently scoped to HTTP/400
-- "detail" (string): A message specific to this type of problem.
-- "instance" (string): A URI reference indicating the HTTP route referenced by the API (excluding query string parameters)
+- "**type**" (string): An optional URI which identifies the problem type.
+- "**title**" (string): Summary of the problem.
+- "**status**" (number): Currently scoped to HTTP/400
+- "**detail**" (string): A message specific to this type of problem.
+- "**instance**" (string): A URI reference indicating the HTTP route referenced by the API (excluding query string parameters)
 
 Note: Object order is not pre-defined or set and can vary.
 
@@ -22,21 +22,35 @@ Note: Object order is not pre-defined or set and can vary.
 
 To provide more specific information about the error condition, the RFC permits extension members to be defined with no limit to the schema. As such, an object array called `validationErrors` is used to hold one or more objects with the following members:
 
-- "code" (string): The error type specific to the validation issue in the collection
-- "target" (string): The name of the parameter which did not validate correctly
-- "message" (string): A descriptive message outlining the constrains of the input
+- "**code**" (string): The error type specific to the validation issue in the collection
+- "**target**" (string): The name of the parameter which did not validate correctly
+- "**message**" (string): A descriptive message outlining the constrains of the input
 
 ## Error Types
 
 Given the above extension member called `validationErrors`, the `code` property can hold the following values:
 
-1. NullValue
-2. MalformedValue
-3. InvalidValue
+1. **NullValue**: Used when the input parameter is null
+2. **InvalidValue**: Used when the input parameter is not the correct type or outside the bounds of the required value(s)
 
 ## Application Type
 
-In accordance with RFC 7807, the application type, also known as the `Content-Type` property of the HTTP response header shall be set to: `application/problem+json`
+In accordance with RFC 7807, the application type, also known as the `Content-Type` property of the HTTP response header, shall be set to: `application/problem+json`
+
+## Parameter Response Messages
+
+|   Parameter    |  Message  |
+|     :--:       |    --     |
+|   'q'          |   The parameter 'q' should be between 2 and 20 characters. |
+|   'actorId'    |   The parameter 'actorId' should start with 'nm' and be between 7 and 11 characters in total. |
+|   'movieId'    |   The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total. |
+|   'year'       |   The parameter 'year' should be between 1874 and {Current Year + 5} |
+|   'genre'      |   The parameter 'genre' should be between 3 and 20 characters. |
+|   'rating'     |   The parameter 'rating' should be between 0 and 10.0 |
+|   'pageSize'   |   The parameter 'pageSize' should be between 1 and 1000. |
+|   'pageNumber' |   The parameter 'pageNumber' should be between 1 and 10000 |
+
+Note: The `year` parameter listed above uses a dynamic range for the maximum value which is today's year plus five (i.e. 2025 at current time of writing).
 
 ## Examples
 
@@ -56,12 +70,12 @@ The following examples show multiple validation errors be triggered on both the 
         {
             "code": "InvalidValue",
             "target": "Year",
-            "message": "The parameter should be between 1874 and 2025."
+            "message": "The parameter 'Year' should be between 1874 and 2025."
         },
                 {
             "code": "InvalidValue",
             "target": "Genre",
-            "message": "The parameter should be between 3 and 20 characters."
+            "message": "The parameter 'Genre' should be between 3 and 20 characters."
         }
     ]
 }

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -1,6 +1,6 @@
 # Helium HTTP/400 Error Response Design
 
-This design guide covers the types of responses and format used when an HTTP/400 error occurs. Aligning with [RFC 7807](https://tools.ietf.org/html/rfc7807), the error responses adhere to this specification with a additional extension members containing a collection of parameter validation errors.
+This design guide covers the types of responses and format used when an HTTP/400 error occurs. Aligning with [RFC 7807](https://tools.ietf.org/html/rfc7807), the error responses adhere to this specification with additional extension members containing a collection of parameter validation errors.
 
 ## Scope
 
@@ -44,17 +44,17 @@ In accordance with [RFC 7807](https://tools.ietf.org/html/rfc7807), the applicat
 |   q            |   The parameter 'q' should be between 2 and 20 characters. |
 |   actorId      |   The parameter 'actorId' should start with 'nm' and be between 7 and 11 characters in total. |
 |   movieId      |   The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total. |
-|   year         |   The parameter 'year' should be between 1874 and {Current Year + 5} |
+|   year         |   The parameter 'year' should be between 1874 and {Current Year + 5}. |
 |   genre        |   The parameter 'genre' should be between 3 and 20 characters. |
-|   rating       |   The parameter 'rating' should be between 0 and 10.0 |
+|   rating       |   The parameter 'rating' should be between 0.0 and 10.0. |
 |   pageSize     |   The parameter 'pageSize' should be between 1 and 1000. |
-|   pageNumber   |   The parameter 'pageNumber' should be between 1 and 10000 |
+|   pageNumber   |   The parameter 'pageNumber' should be between 1 and 10000. |
 
 Note: The `year` parameter listed above uses a dynamic range for the maximum value which is today's year plus five (i.e. 2025 at current time of writing).
 
 ## Examples
 
-The following examples show multiple validation errors be triggered on both the `Movies` and `Actors` APIs.
+The following examples show multiple validation errors triggered on both the `Movies` and `Actors` APIs.
 
 ### Invalid `Movies` API Query Parameter Response
 

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -50,7 +50,7 @@ In accordance with [RFC 7807](https://tools.ietf.org/html/rfc7807), the applicat
 |   pageSize     |   The parameter 'pageSize' should be between 1 and 1000. |
 |   pageNumber   |   The parameter 'pageNumber' should be between 1 and 10000. |
 
-Note: The `year` parameter listed above uses a dynamic range for the maximum value which is today's year plus five (i.e. 2025 at current time of writing).
+>Note: The `year` parameter listed above uses a dynamic range for the maximum value which is today's year plus five (i.e. 2025 at current time of writing).
 
 ## Examples
 

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -1,0 +1,116 @@
+# Helium HTTP/400 Error Response Design
+
+This design guide covers the types of responses and format used when an HTTP/400 error occurs. Aligning with [RFC 7807](https://tools.ietf.org/html/rfc7807), the error responses adhere to this specification with a additional extension members containing a collection of parameter validation errors.
+
+## Scope
+
+The HTTP/400 error responses outlined in this document currently only cover API input parameter validation at this time.
+
+## Base Problem Details Object
+
+The HTTP response contains a "Problem Details Object" which has the following members:
+
+- "type" (string): An optional URI which identifies the problem type.
+- "title" (string): Summary of the problem.
+- "status" (number): Currently scoped to HTTP/400
+- "detail" (string): A message specific to this type of problem.
+- "instance" (string): A URI reference indicating the HTTP route referenced by the API (excluding query string parameters)
+
+Note: Object order is not pre-defined or set and can vary.
+
+## Extension Members
+
+To provide more specific information about the error condition, the RFC permits extension members to be defined with no limit to the schema. As such, an object array called `validationErrors` is used to hold one or more objects with the following members:
+
+- "code" (string): The error type specific to the validation issue in the collection
+- "target" (string): The name of the parameter which did not validate correctly
+- "message" (string): A descriptive message outlining the constrains of the input
+
+## Error Types
+
+Given the above extension member called `validationErrors`, the `code` property can hold the following values:
+
+1. NullValue
+2. MalformedValue
+3. InvalidValue
+
+## Application Type
+
+In accordance with RFC 7807, the application type, also known as the `Content-Type` property of the HTTP response header shall be set to: `application/problem+json`
+
+## Examples
+
+The following examples show multiple validation errors be triggered on both the `Movies` and `Actors` APIs.
+
+### Invalid `Movies` API Query Parameter Response
+
+```json
+
+{
+    "type": "http://www.example.com/validation-error",
+    "title": "Your request parameters did not validate.",
+    "status": 400,
+    "detail": "One or more invalid parameters were specified.",
+    "instance": "/api/movies",
+    "validationErrors": [
+        {
+            "code": "InvalidValue",
+            "target": "Year",
+            "message": "The parameter should be between 1874 and 2025."
+        },
+                {
+            "code": "InvalidValue",
+            "target": "Genre",
+            "message": "The parameter should be between 3 and 20 characters."
+        }
+    ]
+}
+
+```
+
+### Invalid `Actors` API Query Parameter Response
+
+```json
+
+{
+    "type": "http://www.example.com/validation-error",
+    "title": "Your request parameters did not validate.",
+    "status": 400,
+    "detail": "One or more invalid parameters were specified.",
+    "instance": "/api/actors",
+        "validationErrors": [
+        {
+            "code": "InvalidValue",
+            "target": "Q",
+            "message": "The parameter 'q' should be between 2 and 20 characters."
+        },
+        {
+            "code": "InvalidValue",
+            "target": "PageSize",
+            "message": "The parameter 'PageSize' should be between 1 and 1000."
+        }
+    ]
+}
+
+```
+
+### Invalid `Movies` API Route Path Response
+
+```json
+
+{
+    "type": "http://www.example.com/validation-error",
+    "title": "Your request parameters did not validate.",
+    "status": 400,
+    "detail": "One or more invalid parameters were specified.",
+    "instance": "/api/movies/tT0133093",
+        "validationErrors": [
+        {
+            "code": "InvalidValue",
+            "target": "MovieId",
+            "message": "The parameter 'MovieId' should start with 'tt' and be between 7 and 11 characters in total"
+        }
+    ]
+}
+
+```

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -8,23 +8,25 @@ The HTTP/400 error responses outlined in this document currently only cover API 
 
 ## Base Problem Details Object
 
-The HTTP response contains a "Problem Details Object" which has the following members:
+|   Property    |   Type    |   Required    |   Description                                         |
+|:-------------:|:---------:|:-------------:|-------------------------------------------------------|
+|   type        |   String  |               | An optional URI which identifies the problem type.    |
+|   title       |   String  |      ✔       | Summary of the problem.                               |
+|   status      |   Number  |      ✔       | Currently scoped to HTTP/400.                         |
+|   detail      |   String  |      ✔       | A message specific to this type of problem.           |
+|   instance    |   String  |      ✔       | Characters referencing the HTTP route (excluding query string parameters). |
 
-- "**type**" (string): An optional URI which identifies the problem type.
-- "**title**" (string): Summary of the problem.
-- "**status**" (number): Currently scoped to HTTP/400
-- "**detail**" (string): A message specific to this type of problem.
-- "**instance**" (string): A URI reference indicating the HTTP route referenced by the API (excluding query string parameters)
-
-Note: Object order is not pre-defined or set and can vary.
+>Note: Object order in the response body and can vary.
 
 ## Extension Members
 
 To provide more specific information about the error condition, the RFC permits extension members to be defined with no limit to the schema. As such, an object array called `validationErrors` is used to hold one or more objects with the following members:
 
-- "**code**" (string): The error type specific to the validation issue in the collection
-- "**target**" (string): The name of the parameter which did not validate correctly
-- "**message**" (string): A descriptive message outlining the constrains of the input
+|   Property    |   Type    |   Required    |   Description                                         |
+|:-------------:|:---------:|:-------------:|-------------------------------------------------------|
+|   code        |   String  |      ✔       | The error type specific to the validation issue in the collection.    |
+|   target      |   String  |      ✔       | The name of the parameter which did not validate correctly.                               |
+|   message     |   String  |      ✔       | A descriptive message outlining the constrains of the input.                         |
 
 ## Error Types
 

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -41,14 +41,14 @@ In accordance with RFC 7807, the application type, also known as the `Content-Ty
 
 |   Parameter    |  Message  |
 |     :--:       |    --     |
-|   'q'          |   The parameter 'q' should be between 2 and 20 characters. |
-|   'actorId'    |   The parameter 'actorId' should start with 'nm' and be between 7 and 11 characters in total. |
-|   'movieId'    |   The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total. |
-|   'year'       |   The parameter 'year' should be between 1874 and {Current Year + 5} |
-|   'genre'      |   The parameter 'genre' should be between 3 and 20 characters. |
-|   'rating'     |   The parameter 'rating' should be between 0 and 10.0 |
-|   'pageSize'   |   The parameter 'pageSize' should be between 1 and 1000. |
-|   'pageNumber' |   The parameter 'pageNumber' should be between 1 and 10000 |
+|   q            |   The parameter 'q' should be between 2 and 20 characters. |
+|   actorId      |   The parameter 'actorId' should start with 'nm' and be between 7 and 11 characters in total. |
+|   movieId      |   The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total. |
+|   year         |   The parameter 'year' should be between 1874 and {Current Year + 5} |
+|   genre        |   The parameter 'genre' should be between 3 and 20 characters. |
+|   rating       |   The parameter 'rating' should be between 0 and 10.0 |
+|   pageSize     |   The parameter 'pageSize' should be between 1 and 1000. |
+|   pageNumber   |   The parameter 'pageNumber' should be between 1 and 10000 |
 
 Note: The `year` parameter listed above uses a dynamic range for the maximum value which is today's year plus five (i.e. 2025 at current time of writing).
 

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -35,7 +35,7 @@ Given the above extension member called `validationErrors`, the `code` property 
 
 ## Application Type
 
-In accordance with RFC 7807, the application type, also known as the `Content-Type` property of the HTTP response header, shall be set to: `application/problem+json`
+In accordance with [RFC 7807](https://tools.ietf.org/html/rfc7807), the application type, also known as the `Content-Type` property of the HTTP response header, shall be set to: `application/problem+json`
 
 ## Parameter Response Messages
 

--- a/docs/HttpErrorResponses.md
+++ b/docs/HttpErrorResponses.md
@@ -6,15 +6,15 @@ This design guide covers the types of responses and format used when an HTTP/400
 
 The HTTP/400 error responses outlined in this document currently only cover API input parameter validation at this time.
 
-## Base Problem Details Object
+## Problem Details Object
 
 |   Property    |   Type    |   Required    |   Description                                         |
 |:-------------:|:---------:|:-------------:|-------------------------------------------------------|
-|   type        |   String  |               | An optional URI which identifies the problem type.    |
+|   type        |   String  |      ✔       | An optional URI which identifies the problem type.    |
 |   title       |   String  |      ✔       | Summary of the problem.                               |
 |   status      |   Number  |      ✔       | Currently scoped to HTTP/400.                         |
 |   detail      |   String  |      ✔       | A message specific to this type of problem.           |
-|   instance    |   String  |      ✔       | Characters referencing the HTTP route (excluding query string parameters). |
+|   instance    |   String  |      ✔       | Route path (may include query string parameters).     |
 
 >Note: Object order in the response body and can vary.
 
@@ -32,8 +32,8 @@ To provide more specific information about the error condition, the RFC permits 
 
 Given the above extension member called `validationErrors`, the `code` property can hold the following values:
 
-1. **NullValue**: Used when the input parameter is null
-2. **InvalidValue**: Used when the input parameter is not the correct type or outside the bounds of the required value(s)
+1. **NullValue**: Used when the input parameter is null.
+2. **InvalidValue**: Used when the input parameter is not the correct type or outside the bounds of the required value(s).
 
 ## Application Type
 
@@ -63,21 +63,21 @@ The following examples show multiple validation errors triggered on both the `Mo
 ```json
 
 {
-    "type": "http://www.example.com/validation-error",
-    "title": "Your request parameters did not validate.",
+    "type": "https://github.com/retaildevcrews/helium/blob/main/docs/ParameterValidation.md#movies",
+    "title": "Parameter validation error",
     "status": 400,
     "detail": "One or more invalid parameters were specified.",
-    "instance": "/api/movies",
+    "instance": "/api/movies?year=1800&genre=zz",
     "validationErrors": [
         {
             "code": "InvalidValue",
-            "target": "Year",
-            "message": "The parameter 'Year' should be between 1874 and 2025."
+            "target": "year",
+            "message": "The parameter 'year' should be between 1874 and 2025."
         },
                 {
             "code": "InvalidValue",
-            "target": "Genre",
-            "message": "The parameter 'Genre' should be between 3 and 20 characters."
+            "target": "genre",
+            "message": "The parameter 'genre' should be between 3 and 20 characters."
         }
     ]
 }
@@ -89,42 +89,42 @@ The following examples show multiple validation errors triggered on both the `Mo
 ```json
 
 {
-    "type": "http://www.example.com/validation-error",
-    "title": "Your request parameters did not validate.",
+    "type": "https://github.com/retaildevcrews/helium/blob/main/docs/ParameterValidation.md#actors",
+    "title": "Parameter validation error",
     "status": 400,
     "detail": "One or more invalid parameters were specified.",
-    "instance": "/api/actors",
-        "validationErrors": [
+    "instance": "/api/actors?q=a&pageSize=99999",
+    "validationErrors": [
         {
             "code": "InvalidValue",
-            "target": "Q",
+            "target": "q",
             "message": "The parameter 'q' should be between 2 and 20 characters."
         },
         {
             "code": "InvalidValue",
-            "target": "PageSize",
-            "message": "The parameter 'PageSize' should be between 1 and 1000."
+            "target": "pageSize",
+            "message": "The parameter 'pageSize' should be between 1 and 1000."
         }
     ]
 }
 
 ```
 
-### Invalid `Movies` API Route Path Response
+### Invalid `Movies` API Direct Read Response
 
 ```json
 
 {
-    "type": "http://www.example.com/validation-error",
-    "title": "Your request parameters did not validate.",
+    "type": "https://github.com/retaildevcrews/helium/blob/main/docs/ParameterValidation.md#direct-read",
+    "title": "Parameter validation error",
     "status": 400,
     "detail": "One or more invalid parameters were specified.",
     "instance": "/api/movies/tT0133093",
-        "validationErrors": [
+    "validationErrors": [
         {
             "code": "InvalidValue",
-            "target": "MovieId",
-            "message": "The parameter 'MovieId' should start with 'tt' and be between 7 and 11 characters in total"
+            "target": "movieId",
+            "message": "The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total"
         }
     ]
 }

--- a/docs/ParameterValidation.md
+++ b/docs/ParameterValidation.md
@@ -48,8 +48,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input: length [2, 20]
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid q parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 - Name: pageSize
 - Type: integer
@@ -63,8 +63,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input: non-integer or out of range
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid pageSize parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 - Name: pageNumber
 - Type: integer
@@ -78,8 +78,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input: non-integer or out of range
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid pageNumber parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 ## Movies
 
@@ -99,8 +99,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input: input that does not parse or is out of range
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid year parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 - Name: rating
 - Type: double
@@ -113,8 +113,8 @@ Define valid Query String and URL parameters for the Helium API
     - Response Body: array of `Movie`
   - Invalid input: does not parse or out of range
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid rating parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 - Name: actorId
 - Type: string
@@ -130,8 +130,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input:
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid actorId parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 - Name: genre
 - Type: string
@@ -145,8 +145,8 @@ Define valid Query String and URL parameters for the Helium API
       - Empty array when no results
   - Invalid input: length [3, 20]
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid genre parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 ### Direct Read
 
@@ -168,8 +168,8 @@ Define valid Query String and URL parameters for the Helium API
     - Response Body: none
   - Invalid input:
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid movieId parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response
 
 ## Actors
 
@@ -199,5 +199,5 @@ Define valid Query String and URL parameters for the Helium API
     - Response Body: none
   - Invalid input:
     - Status: 400
-    - Content-Type: text/plain
-    - Response Body: Invalid actorId parameter
+    - Content-Type: application/problem+json
+    - Response Body: RFC 7807 compliant response

--- a/docs/ParameterValidation.md
+++ b/docs/ParameterValidation.md
@@ -20,12 +20,16 @@ Define valid Query String and URL parameters for the Helium API
 
 - Parameter validation fails on the first error
 - Additional query string parameters are ignored
-- Additional URL paramaters result in 404 Not Found
+- Additional URL parameters result in 404 Not Found
   - example: /api/movies/tt12345/foo
 - Specifying multiple instances of a query string is an error and results are unpredictable
   - Results are idiomatic to the language / framework used
     - i.e. /api/movies?year=1998&year=1999 will return 400 on some frameworks
     - while /api/movies?genre=action&genre=comedy will use the first value
+
+### Error Response Format
+
+The error response to parameter or route path validation errors uses a combination of RFC 7807 and the Microsoft REST API guidelines and can be found on the [HttpErrorResponses](HttpErrorResponses.md) page.
 
 ## Common Parameters
 
@@ -49,7 +53,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: length [2, 20]
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 - Name: pageSize
 - Type: integer
@@ -64,7 +68,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: non-integer or out of range
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 - Name: pageNumber
 - Type: integer
@@ -79,7 +83,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: non-integer or out of range
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 ## Movies
 
@@ -100,7 +104,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: input that does not parse or is out of range
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 - Name: rating
 - Type: double
@@ -114,7 +118,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: does not parse or out of range
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 - Name: actorId
 - Type: string
@@ -131,7 +135,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input:
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 - Name: genre
 - Type: string
@@ -146,7 +150,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input: length [3, 20]
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 ### Direct Read
 
@@ -169,7 +173,7 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input:
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)
 
 ## Actors
 
@@ -200,4 +204,4 @@ Define valid Query String and URL parameters for the Helium API
   - Invalid input:
     - Status: 400
     - Content-Type: application/problem+json
-    - Response Body: RFC 7807 compliant response
+    - Response Body: [HttpErrorResponses](HttpErrorResponses.md)


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Update common HTTP error response schema for all three code bases.
- Use combined format of RFC 7807 and Microsoft REST API guidelines
- Provide developer documentation/guidance on response format

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced
N/A

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References #issue_number (this references the issue but does not close with PR)
