### PR TITLE
Added scheduled link checker for markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/found-dead-links.md
+++ b/.github/ISSUE_TEMPLATE/found-dead-links.md
@@ -1,12 +1,10 @@
 ---
 name: Found Dead Links
 about: Dead link
-title: 'Dead link(s) found in markdown files'
+title: 'Dead link(s) found in markdown files in helium repository'
 labels: 'Documentation'
 assignees: ''
 
 ---
 
-To find the dead links, run the following commands in the top-level directory:
-- npm install -g markdown-link-check
-- find . -name \\\*.md -exec markdown-link-check -c mlc_config.json {} \\\;
+To find the dead links, please review the GitHub Actions logs for this repository

--- a/.github/ISSUE_TEMPLATE/found-dead-links.md
+++ b/.github/ISSUE_TEMPLATE/found-dead-links.md
@@ -1,0 +1,12 @@
+---
+name: Found Dead Links
+about: Dead link
+title: 'Dead link(s) found in markdown files'
+labels: 'Documentation'
+assignees: ''
+
+---
+
+To find the dead links, run the following commands in the top-level directory:
+- npm install -g markdown-link-check
+- find . -name \\\*.md -exec markdown-link-check -c mlc_config.json {} \\\;

--- a/.github/workflows/mdlinkcheck.yml
+++ b/.github/workflows/mdlinkcheck.yml
@@ -1,6 +1,6 @@
 name: Check Markdown links
 
-on: push
+on: [pull_request]
 
 jobs:
   markdown-link-check:
@@ -12,3 +12,4 @@ jobs:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         config-file: 'mlc_config.json'
+        check-modified-files-only: 'yes'

--- a/.github/workflows/mdlinkcheck.yml
+++ b/.github/workflows/mdlinkcheck.yml
@@ -1,4 +1,4 @@
-name: Check Markdown links
+name: Check Markdown Links
 
 on: [pull_request]
 

--- a/.github/workflows/mdlinkcheck.yml
+++ b/.github/workflows/mdlinkcheck.yml
@@ -13,3 +13,4 @@ jobs:
         use-verbose-mode: 'yes'
         config-file: 'mlc_config.json'
         check-modified-files-only: 'yes'
+        base-branch: 'main'

--- a/.github/workflows/mdlinkcheck.yml
+++ b/.github/workflows/mdlinkcheck.yml
@@ -6,7 +6,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -1,0 +1,34 @@
+name: Check Markdown links
+
+on: 
+  schedule:
+  # Run on the 1st and 15th of every month at 2:00 AM 
+  - cron: "0 2 1,15 * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: 'mlc_config.json'
+
+    - name: Create Issue From File
+      if: ${{ failure() }}
+      id: ciff
+      uses: peter-evans/create-issue-from-file@v2
+      with:
+        title: Remove dead links from repository
+        content-filepath: ./.github/ISSUE_TEMPLATE/found-dead-links.md
+
+    - name: Create Project Card
+      if: ${{ failure() }}
+      uses: peter-evans/create-or-update-project-card@v1
+      with:
+        project-number: '1'
+        column-name: 'To do'
+        issue-number: ${{ steps.ciff.outputs.issue-number }}
+    

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -2,7 +2,7 @@ name: Check Markdown Links
 
 on: 
   schedule:
-  # Run on the 1st and 15th of every month at 2:00 AM 
+  # Run on the 1st, 8th, 15th and 22nd of every month at 2:00 AM 
   - cron: "0 2 1,8,15,22 * *"
 
 jobs:

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -1,4 +1,4 @@
-name: Check Markdown links
+name: Check Markdown Links
 
 on: 
   schedule:

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -3,7 +3,7 @@ name: Check Markdown links
 on: 
   schedule:
   # Run on the 1st and 15th of every month at 2:00 AM 
-  - cron: "0 2 1,15 * *"
+  - cron: "0 2 1,8,15,22 * *"
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/scheduled_mdlinkcheck.yml
+++ b/.github/workflows/scheduled_mdlinkcheck.yml
@@ -29,6 +29,6 @@ jobs:
       uses: peter-evans/create-or-update-project-card@v1
       with:
         project-number: '1'
-        column-name: 'To do'
+        column-name: 'Triage'
         issue-number: ${{ steps.ciff.outputs.issue-number }}
     


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Added a scheduled link checker for markdown files to CI. It is scheduled to run on the 1st, 8th,15th and 22nd of every month. The workflow creates an issue and a card in the Triage column of the Helium project Kanban board if it finds a dead link. This checker is implemented separately from the checker that runs after every pull request, because those checks only run on modified documents, and do not automatically create an issue or a card on the Kanban board.

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References #/helium/issues/542
