### PR TITLE
issue #541 replace deprecated ingress helm chart with app gateway ingress

### DIFF
--- a/docs/AppServiceObservability.md
+++ b/docs/AppServiceObservability.md
@@ -154,7 +154,7 @@ after making sure the proper environment variables are set (He_Sub, He_App_RG, I
 
 ```bash
 
-curl -s https://raw.githubusercontent.com/retaildevcrews/helium/master/docs/dashboard/Helium_Dashboard.json > Helium_Dashboard.json
+curl -s https://raw.githubusercontent.com/retaildevcrews/helium/main/docs/dashboard/Helium_Dashboard.json > Helium_Dashboard.json
 sed -i "s/%%SUBSCRIPTION_GUID%%/$(eval $He_Sub)/g" Helium_Dashboard.json
 sed -i "s/%%He_App_RG%%/${He_App_RG}/g" Helium_Dashboard.json
 sed -i "s/%%Imdb_RG%%/${Imdb_RG}/g" Helium_Dashboard.json

--- a/docs/aks/README.md
+++ b/docs/aks/README.md
@@ -398,7 +398,7 @@ helm install ingress ingress-nginx/ingress-nginx \
 
 # Add the ingress controller pods to the linkerd service mesh AFTER the controller is up and running.
 # If the namespace has this annotation before installing the ingress controller, then the install will fail.
-# The cause is a pod that is stuck in the "NotReady" because of a completed ingress-nginx job, and a running linkered container.
+# The cause is a Pod that is stuck in the "NotReady" state because of a completed ingress-nginx container from a Job, and a running linkerd proxy container.
 kubectl annotate namespace ingress-nginx linkerd.io/inject='enabled'
 kubectl get deployment ingress-ingress-nginx-controller --namespace ingress-nginx -o yaml \
   | linkerd inject - \

--- a/docs/aks/README.md
+++ b/docs/aks/README.md
@@ -324,16 +324,15 @@ helm repo update
 
 ### Install AAD Pod Identity for the application
 
-Change directories to the `docs/aks` folder and make the `aad-podid.sh` script executable. Running this shell script will deploy AAD Pod Identity to your cluster and assign a Managed Identity.
+Change directories to the `docs/aks` folder. Running this shell script will deploy AAD Pod Identity to your cluster and assign a Managed Identity.
 
->NOTE: The second command below has a `.` then a space followed by `./aad-podid.sh ...` this is so the exported variables in the script persist after the script ends in the uder interactive shell
+>NOTE: The second command below has a `.` then a space followed by `./aad-podid.sh ...` this is so the exported variables in the script persist after the script ends in the outer interactive shell
 
 ```bash
 
 export MI_Name=${He_Name}-mi
 
 cd $REPO_ROOT/docs/aks
-sudo chmod +x aad-podid.sh
 
 . ./aad-podid.sh -a ${He_AKS_Name} -r ${He_App_RG} -m ${MI_Name}
 
@@ -354,7 +353,7 @@ echo $MI_Name
 
 ```bash
 
-az keyvault set-policy -n ${He_Name} --object-id ${MI_PrincID} --secret-permissions get list --key-permissions get list --certificate-permissions get list
+az keyvault set-policy -n ${He_Name} --object-id ${MI_PrincID} --secret-permissions get list
 
 ```
 

--- a/docs/aks/aad-podid.sh
+++ b/docs/aks/aad-podid.sh
@@ -114,14 +114,6 @@ if echo $AKS_IDENTITY_ID > /dev/null 2>&1 && echo $AKS_NODE_RG > /dev/null 2>&1;
     fi
 fi
 
-# echo "assigning the Managed Identity access rights to the Azure Key Vault"
-# if echo $KEY_VAULT_NAME > /dev/null 2>&1 && echo $MI_PrincID > /dev/null 2>&1; then
-#     if ! az keyvault set-policy -n $KEY_VAULT_NAME --object-id $MI_PrincID --secret-permissions get list --key-permissions get list --certificate-permissions get list; then
-#         echo "ERROR: failed to assign the Managed Identity access rights to the Azure Key Vault"
-#         exit 1
-#     fi
-# fi
-
 # write aad helm chart values file.
 cat << EOF > cluster/manifests/aadpodidentity/${MI_NAME}-values.yaml
 azureIdentities:
@@ -151,8 +143,7 @@ echo "**************************************************************************
 echo " "
 echo "******************************************************************************************************************"
 echo "To assign the MI to your keyvault run the following:"
-echo "az keyvault set-policy -n ${He_Name} --object-id ${MI_PrincID} --secret-permissions get list \\"
-echo "--key-permissions get list --certificate-permissions get list"
+echo "az keyvault set-policy -n ${He_Name} --object-id ${MI_PrincID} --secret-permissions get list"
 echo "******************************************************************************************************************"
 echo " "
 echo "******************************************************************************************************************"

--- a/docs/aks/aad-podid.sh
+++ b/docs/aks/aad-podid.sh
@@ -137,7 +137,7 @@ EOF
 
 echo "creating aad-pod-identity deployment in the default namespace with values file "
 if ! kubectl get deploy mic > /dev/null 2>&1; then
-    if ! helm install aad-pod-identity aad-pod-identity/aad-pod-identity -f cluster/manifests/aadpodidentity/${MI_NAME}-values.yaml; then
+    if ! helm install aad-pod-identity aad-pod-identity/aad-pod-identity -f cluster/manifests/aadpodidentity/${MI_NAME}-values.yaml --version 2.0.1; then
         echo "ERROR: failed to create kubernetes aad-pod-idenity deployment"
         exit 1
     fi

--- a/docs/aks/cluster/charts/helium/helm-config.yaml
+++ b/docs/aks/cluster/charts/helium/helm-config.yaml
@@ -14,7 +14,6 @@ annotations:
 
 ingress:
   hosts:
-    - host: %%INGRESS_PIP%%.nip.io # Replace the IP address with the IP of the nginx external IP. kubectl get svc -n ingress-nginx to see the correct IP
-      paths: /
+    - paths: /
 
 keyVaultName: %%KV_Name%% # Replace with the name of the Key Vault that holds the secrets

--- a/docs/aks/cluster/charts/helium/helm-config.yaml
+++ b/docs/aks/cluster/charts/helium/helm-config.yaml
@@ -14,6 +14,7 @@ annotations:
 
 ingress:
   hosts:
-    - paths: /
+    - host: %%INGRESS_PIP%%.nip.io # Replace the IP address with the IP of the nginx external IP. kubectl get svc -n ingress-nginx to see the correct IP
+      paths: /
 
 keyVaultName: %%KV_Name%% # Replace with the name of the Key Vault that holds the secrets

--- a/docs/aks/cluster/charts/helium/templates/heliumcs-ingress.yaml
+++ b/docs/aks/cluster/charts/helium/templates/heliumcs-ingress.yaml
@@ -29,8 +29,7 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    - http:
         paths:
           - path: {{ $path }}
             backend:

--- a/docs/aks/cluster/charts/helium/templates/heliumcs-ingress.yaml
+++ b/docs/aks/cluster/charts/helium/templates/heliumcs-ingress.yaml
@@ -29,7 +29,8 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - http:
+    - host: {{ .host | quote }}
+      http:
         paths:
           - path: {{ $path }}
             backend:

--- a/docs/aks/cluster/charts/helium/values.yaml
+++ b/docs/aks/cluster/charts/helium/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 
 annotations:
   linkerd.io/inject: enabled
-  
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -42,22 +42,21 @@ service:
 
 ingress:
   enabled: true
-  annotations: 
-    kubernetes.io/ingress.class: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:4120;
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
   hosts:
-    - host: 52.230.216.170.nip.io
-      paths: /
+    - paths: /
 
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: 
+resources:
   limits:
     cpu: 200m
     memory: 256Mi

--- a/docs/aks/cluster/charts/helium/values.yaml
+++ b/docs/aks/cluster/charts/helium/values.yaml
@@ -43,13 +43,14 @@ service:
 ingress:
   enabled: true
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:4120;
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
   hosts:
-    - paths: /
+    - host: 52.230.216.170.nip.io
+      paths: /
 
   tls: []
   #  - secretName: chart-example-tls

--- a/docs/aks/cluster/manifests/ingress-nginx-namespace.yaml
+++ b/docs/aks/cluster/manifests/ingress-nginx-namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    fluxcd.io/ignore: "false"
-    linkerd.io/inject: enabled
-  name: ingress-nginx

--- a/docs/aks/cluster/manifests/ingress-nginx-namespace.yaml
+++ b/docs/aks/cluster/manifests/ingress-nginx-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    fluxcd.io/ignore: "false"
+  name: ingress-nginx


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Replaces a deprecated nginx-ingress helm chart with the new version.

- update docs to add the new ingress-nginx helm repo
- add the ingress controller and namespace to linkerd after the controller is up and running. without this change, the helm install will fail.
- fix broken link in observability docs
- pin aad pod identity helm chart to a specific version we know works with our values file

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #541 
